### PR TITLE
Change source location of hubot-maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hubot-google-translate": "^0.1.0",
     "hubot-help": "^0.1.1",
     "hubot-heroku-keepalive": "0.0.4",
-    "hubot-maps": "0.0.0",
+    "hubot-maps": "git://github.com/wildtree/hubot-maps.git#multibyte",
     "hubot-multiline-test": "git://github.com/prototype-cafe/hubot-multiline-test.git",
     "hubot-otsukare-yamero": "git://github.com/prototype-cafe/hubot-otsukare-yamero.git",
     "hubot-pugme": "^0.1.0",


### PR DESCRIPTION
hubot-mapsが動作するようにpackageの参照先を変更しました。

Reference: https://github.com/prototype-cafe/cafeo/pull/6
